### PR TITLE
release/0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.3.10
+- Fixed an issue where banners with start months greater than the end month would not be included in the banner rotation
+- Package hygiene
+  - Set the `cmd2` package to `<3` to avoid compatibility issues with future releases
+  - Commented out `gnureadline` due to broader compatibility issues
+
 ## 0.3.9
 - Added the freshness column to report outputs
 - Added `report --suppress-freshness` to exclude freshness from reports

--- a/CloudHarvestCLI/banner.py
+++ b/CloudHarvestCLI/banner.py
@@ -332,8 +332,8 @@ def _get_eligible_banners(banner_configuration: dict) -> list:
 
                     # start 11, end 3
                     if start_date['month'] > end_date['month']:
-                        start = date(**start_date, year=now.year - 1)
-                        end = date(**end_date, year=now.year)
+                        start = date(**start_date, year=now.year)
+                        end = date(**end_date, year=now.year + 1)
 
                     else:
                         start = date(**start_date, year=now.year)

--- a/CloudHarvestCLI/pyproject.toml
+++ b/CloudHarvestCLI/pyproject.toml
@@ -14,8 +14,8 @@ classifiers = [ "Programming Language :: Python :: 3.13" ]
 dependencies = [
     "CloudHarvestCoreTasks @ git+https://github.com/Cloud-Harvest/CloudHarvestCoreTasks.git@0.8.1",
     "PyYAML",
-    "cmd2",
-    "gnureadline",
+    "cmd2<3",
+#    "gnureadline",
     "flatten-json",
     "natsort",
     "pandas",
@@ -31,7 +31,7 @@ description = "This is the CLI for CloudHarvest, providing a command-line interf
 name = "CloudHarvestCLI"
 readme = "README.md"
 requires-python = ">=3.13"
-version = "0.3.9"
+version = "0.3.10"
 
 [project.license]
 file = "LICENSE"


### PR DESCRIPTION
## 0.3.10
- Fixed an issue where banners with start months greater than the end month would not be included in the banner rotation
- Package hygiene
  - Set the `cmd2` package to `<3` to avoid compatibility issues with future releases
  - Commented out `gnureadline` due to broader compatibility issues
